### PR TITLE
Update 07_install_blinka.rst

### DIFF
--- a/docs/source/05_raspberry_pi/raspberry_start/07_install_blinka.rst
+++ b/docs/source/05_raspberry_pi/raspberry_start/07_install_blinka.rst
@@ -94,7 +94,7 @@ Create a new file called ``blinkatest.py`` with nano or your favorite text edito
    print("Hello blinka!")
    
    # Try to great a Digital input
-   pin = digitalio.DigitalInOut(board.17)
+   pin = digitalio.DigitalInOut(board.D17)
    print("Digital IO ok!")
    
    # Try to create an I2C device


### PR DESCRIPTION
Referencing as 17 was throwing error.

board.17 is not a valid way to reference a pin. You should reference pins by their actual name on the board, such as board.D17 (not just 17)